### PR TITLE
Upgrade kafka-python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-kafka-python==0.9.2
+kafka-python==0.9.5
 logstash-formatter==0.5.8

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open('README.rst', 'r', 'utf-8') as f:
 
 setup(
     name='python_kafka_logging',
-    version=0.4,
+    version=0.5,
     description='Simple python logging handler for forwarding logs to a kafka server.',
     long_description=readme + '\n\n',
     maintainer="Taykey INC",


### PR DESCRIPTION
I'm using a newer version of kafka-python .9.5 in another project that also uses python-kafka-logging, and since this retains compatibility, I figured why not keep the versions in sync
