### PR TITLE
Compatible with different pip versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,10 @@
 import os
 import sys
 import uuid
-from pip.req import parse_requirements
+try: 
+    from pip._internal.req import parse_requirements
+except ImportError: 
+    from pip.req import parse_requirements
 from codecs import open
 
 


### PR DESCRIPTION
pip install always got error: ModuleNotFoundError: No module named 'pip.req'. so in the setup.py we should compatible with different pip versions.